### PR TITLE
Compiling for Ubuntu 17.04 + C-compatibility (no C++ runtime)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -87,7 +87,7 @@ $(LIB)/libsupermalloc_pthread.so: $(PTHREAD_OFILES) | $(LIB)
 	$(CXX) $(CXXFLAGS) $^ -shared $(LDLIBS) -o $@
 
 $(BLD)/supermalloc.a: $(OFILES)
-	ar cr $(BLD)/supermalloc.a $(OFILES)
+	gcc-ar cr $(BLD)/supermalloc.a $(OFILES)
 $(BLD)/%.o: $(SRC)/%.cc
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -10,7 +10,7 @@ RTMFLAGS = -mrtm
 endif
 
 C_CXX_FLAGS = -W -Wall -Werror $(OPTFLAGS) -ggdb -pthread -fPIC $(RTMFLAGS) $(COVERAGE)
-CXXFLAGS = $(C_CXX_FLAGS) -std=c++11
+CXXFLAGS = $(C_CXX_FLAGS) -std=c++11 -fno-exceptions
 CFLAGS = $(C_CXX_FLAGS) -std=c11
 CPPFLAGS += $(STATS) $(LOGCHECK) $(TESTING) -I$(BLD)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -9,10 +9,16 @@ else
 RTMFLAGS = -mrtm
 endif
 
+ifdef PREFIX
+  PREFIXOPT = -DPREFIX=$(PREFIX)
+else
+  PREFIXOPT =
+endif
+
 C_CXX_FLAGS = -W -Wall -Werror $(OPTFLAGS) -ggdb -pthread -fPIC $(RTMFLAGS) $(COVERAGE)
 CXXFLAGS = $(C_CXX_FLAGS) -std=c++11 -fno-exceptions
 CFLAGS = $(C_CXX_FLAGS) -std=c11
-CPPFLAGS += $(STATS) $(LOGCHECK) $(TESTING) -I$(BLD)
+CPPFLAGS += $(STATS) $(LOGCHECK) $(TESTING) -I$(BLD) $(PREFIXOPT)
 
 LIBOBJECTS = malloc makechunk rng huge_malloc large_malloc small_malloc cache bassert footprint stats futex_mutex generated_constants has_tsx
 default: tests $(LIB)/libsupermalloc_pthread.so

--- a/src/has_tsx.cc
+++ b/src/has_tsx.cc
@@ -27,7 +27,9 @@ if( result ) assert( (reg_ebx & rtm_ebx_mask)!=0 );
     return result;
 }
 
+#if 0
 int main () {
   printf("have_TSX=%d\n", have_TSX());
   return 0;
 }
+#endif

--- a/src/malloc.cc
+++ b/src/malloc.cc
@@ -1,6 +1,7 @@
 #include "supermalloc.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>

--- a/src/objsizes.cc
+++ b/src/objsizes.cc
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <vector>
 
 #include "malloc_internal.h"
 


### PR DESCRIPTION
Also, I've made it so you can change the name of the exported functions by specifying the PREFIX option on the make line:

% make PREFIX=__super_

__super_malloc instead of malloc
__super_free instead of free
etc.
