### PR TITLE
Add a build option to remove references to C++ runtime

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -9,6 +9,14 @@ else
 RTMFLAGS = -mrtm
 endif
 
+ifdef NOCPPRUNTIME
+  CPPRUNTIME = -DNOCPPRUNTIME=1
+  EXCEPTIONS = -fno-exceptions
+else
+  CPPRUNTIME =
+  EXCEPTIONS =
+endif
+
 ifdef PREFIX
   PREFIXOPT = -DPREFIX=$(PREFIX)
 else
@@ -16,9 +24,9 @@ else
 endif
 
 C_CXX_FLAGS = -W -Wall -Werror $(OPTFLAGS) -ggdb -pthread -fPIC $(RTMFLAGS) $(COVERAGE)
-CXXFLAGS = $(C_CXX_FLAGS) -std=c++11 -fno-exceptions
+CXXFLAGS = $(C_CXX_FLAGS) -std=c++11 $(EXCEPTIONS)
 CFLAGS = $(C_CXX_FLAGS) -std=c11
-CPPFLAGS += $(STATS) $(LOGCHECK) $(TESTING) -I$(BLD) $(PREFIXOPT)
+CPPFLAGS += $(STATS) $(LOGCHECK) $(TESTING) -I$(BLD) $(PREFIXOPT) $(CPPRUNTIME)
 
 LIBOBJECTS = malloc makechunk rng huge_malloc large_malloc small_malloc cache bassert footprint stats futex_mutex generated_constants has_tsx
 default: tests $(LIB)/libsupermalloc_pthread.so

--- a/Makefile.include
+++ b/Makefile.include
@@ -28,7 +28,7 @@ CXXFLAGS = $(C_CXX_FLAGS) -std=c++11 $(EXCEPTIONS)
 CFLAGS = $(C_CXX_FLAGS) -std=c11
 CPPFLAGS += $(STATS) $(LOGCHECK) $(TESTING) -I$(BLD) $(PREFIXOPT) $(CPPRUNTIME)
 
-LIBOBJECTS = malloc makechunk rng huge_malloc large_malloc small_malloc cache bassert footprint stats futex_mutex generated_constants has_tsx
+LIBOBJECTS = malloc makechunk rng huge_malloc large_malloc small_malloc cache bassert footprint stats futex_mutex generated_constants has_tsx env
 default: tests $(LIB)/libsupermalloc_pthread.so
 .PHONY: default
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -29,7 +29,7 @@ CFLAGS = $(C_CXX_FLAGS) -std=c11
 CPPFLAGS += $(STATS) $(LOGCHECK) $(TESTING) -I$(BLD) $(PREFIXOPT) $(CPPRUNTIME)
 
 LIBOBJECTS = malloc makechunk rng huge_malloc large_malloc small_malloc cache bassert footprint stats futex_mutex generated_constants has_tsx env
-default: tests $(LIB)/libsupermalloc_pthread.so
+default: tests
 .PHONY: default
 
 -include $(patsubst %, $(BLD)/%.d, $(LIBOBJECTS))
@@ -87,18 +87,13 @@ check-test-malloc_test-w1-s-1: $(BLD)/test-malloc_test
 	SUPERMALLOC_THREADCACHE=0 $< -w1 -s -1
 
 OFILES = $(patsubst %, $(BLD)/%.o, $(LIBOBJECTS))
-PTHREAD_OFILES = $(patsubst %, $(BLD)/%_pthread.o, $(LIBOBJECTS))
-
-ALL_OFILES = $(OFILES) $(PTHREAD_OFILES)
 
 $(LIB):
 	mkdir -p $(LIB)
-$(LIB)/libsupermalloc.so: $(OFILES) | $(LIB)
-	mkdir -p $(LIB)
-	$(CXX) $(CXXFLAGS) $^ -shared $(LDLIBS) -o $@
-$(LIB)/libsupermalloc_pthread.so: $(PTHREAD_OFILES) | $(LIB)
-	mkdir -p $(LIB)
-	$(CXX) $(CXXFLAGS) $^ -shared $(LDLIBS) -o $@
+$(LIB)/supermalloc.a: $(OFILES) | $(LIB)
+	gcc-ar cr $(LIB)/supermalloc.a $(OFILES)
+$(LIB)/libsupermalloc.so: $(LIB)/supermalloc.a $(OFILES) | $(LIB)
+	$(CXX) $(CXXFLAGS) $(OFILES) -shared $(LDLIBS) -o $@
 
 $(BLD)/supermalloc.a: $(OFILES)
 	gcc-ar cr $(BLD)/supermalloc.a $(OFILES)
@@ -118,11 +113,6 @@ $(BLD)/%.d: $(SRC)/%.cc
 #	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@
 #	rm -f $@.$$$$
 
-$(BLD)/%_pthread.o: $(SRC)/%.cc
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -DUSE_PTHREAD_MUTEXES -c $< -o $@
-$(BLD)/generated_constants_pthread.o: $(BLD)/generated_constants.cc
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -DUSE_PTHREAD_MUTEXES -c $< -o $@
-
 $(BLD)/%.o: CPPFLAGS += -I$(SRC) 
 $(BLD)/%.o: $(TST)/%.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
@@ -131,7 +121,7 @@ $(BLD)/%.o: $(TST)/%.cc
 $(BLD)/%: $(BLD)/%.o
 	$(CXX) $(CXXFLAGS) $< $(LDFLAGS) $(LDLIBS) $(IMPLEMENTATION_FILES) -o $@
 
-$(filter-out %/bassert.o,$(PTHREAD_OFILES) $(OFILES)): $(BLD)/generated_constants.h
+$(filter-out %/bassert.o, $(OFILES)): $(BLD)/generated_constants.h
 
 # The rule below with a pattern is preferable to the one commented out below because the commented out one will cause ./objsizes to be run twice (which is wrong and racy).  
 # A pattern rule, on the other hand, when it has multiple targets, is understood to produce all the outputs with a single run.

--- a/src/env.cc
+++ b/src/env.cc
@@ -1,0 +1,34 @@
+#include "atomically.h"
+#include "has_tsx.h"
+#include <cstring>
+#include <stdio.h>
+
+#define ENV_MODE_STRING "SUPERMALLOC_MODE"
+
+mutex_mode_t mode;
+
+static inline mutex_mode_t default_mode() {
+  return have_TSX() ? MODE_TSX : MODE_PTHREAD_MUTEX;
+}
+
+__attribute__((constructor (101)))
+void __setup_supermalloc_env() {
+  const char *mode_str = getenv(ENV_MODE_STRING);
+
+  if (NULL == mode_str) {
+    mode = default_mode();
+  } else {
+    if (0 == std::strcmp("tsx", mode_str)) {
+      if (!have_TSX()) {
+	fprintf(stderr, "SuperMalloc: Warning: TSX mode unsupported on this"
+		"machine.\n  This application will likely crash.\n");
+      }
+      mode = MODE_TSX;
+    } else if (0 == std::strcmp("pthread_mutex", mode_str)) {
+      mode = MODE_PTHREAD_MUTEX;
+    } else {
+      fprintf(stderr, "SuperMalloc: Warning: unknown mode '%s'.\n", mode_str);
+      mode = default_mode();
+    }
+  }
+}

--- a/src/malloc.cc
+++ b/src/malloc.cc
@@ -76,7 +76,6 @@ struct chunk_info *chunk_infos;
 
 uint32_t n_cores;
 
-#ifndef USE_PTHREAD_MUTEXES
 #ifdef DO_FAILED_COUNTS
 atomic_stats_s atomic_stats;
 
@@ -93,7 +92,6 @@ int compare_failed_counts(const void *a_v, const void *b_v) {
   if (a->code > b->code) return +1;
   return 0;
 }
-#endif
 #endif
 
 #if 0

--- a/src/small_malloc.cc
+++ b/src/small_malloc.cc
@@ -344,6 +344,7 @@ void* small_malloc(binnumber_t bin)
   }
 }
 
+#ifndef NOCPPRUNTIME
 // We want this timing especially when not in test code.
 extern "C" void time_small_malloc(void) {
   // measure the time to do small mallocs.
@@ -385,6 +386,7 @@ extern "C" void time_small_malloc(void) {
   }
   delete [] array;
 }
+#endif // !defined NOCPPRUNTIME
 
 static void predo_small_free(binnumber_t bin,
 			     per_folio *pp,


### PR DESCRIPTION
% make NOCPPRUNTIME=true

It omits the time-testing function for small allocations.  Not suitable for testing, but good for C users.