### PR TITLE
tweak source code to compile with clang

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -355,8 +355,13 @@ static void collect_objects_for_thread_cache(cached_objects *objects,
   }
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
 __attribute__((optimize("unroll-loops")))
+#endif
 static void predo_fetch_one_from_cpu(CacheForBin *cc, size_t siz __attribute__((unused))) {
+#if defined(__clang__)
+  #pragma unroll
+#endif
   for (int i = 0; i < 2 ; i++) {
     linked_list *result = cc->co[i].head;
     if (result) {
@@ -367,8 +372,13 @@ static void predo_fetch_one_from_cpu(CacheForBin *cc, size_t siz __attribute__((
   }
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
 __attribute__((optimize("unroll-loops")))
+#endif
 static void* do_fetch_one_from_cpu(CacheForBin *cc, size_t siz) {
+#if defined(__clang__)
+  #pragma unroll
+#endif
   for (int i = 0; i < 2; i++) {
     linked_list *result = cc->co[i].head;
     if (result) {
@@ -676,10 +686,16 @@ static bool do_put_into_cpu_cache(linked_list *obj,
   return false;
 }
 
+
+#if defined(__GNUC__) && !defined(__clang__)
 __attribute__((optimize("unroll-loops")))
+#endif
 static void predo_put_one_into_cpu_cache(linked_list *obj,
 					 CacheForBin *cc,
 					 uint64_t siz __attribute__((unused))) {
+#if defined(__clang__)
+  #pragma unroll
+#endif
   for (int i = 0; i < 2; i++) {
     uint64_t old_bytecount = cc->co[i].bytecount;
     if (old_bytecount < per_cpu_cache_bytecount_limit) {
@@ -691,10 +707,15 @@ static void predo_put_one_into_cpu_cache(linked_list *obj,
   }
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
 __attribute__((optimize("unroll-loops")))
+#endif
 static bool do_put_one_into_cpu_cache(linked_list *obj,
 				      CacheForBin *cc,
 				      uint64_t siz) {
+#if defined(__clang__)
+  #pragma unroll
+#endif
   for (int i = 0; i < 2; i++) {
     uint64_t old_bytecount = cc->co[i].bytecount;
     if (old_bytecount < per_cpu_cache_bytecount_limit) {

--- a/src/futex_mutex.cc
+++ b/src/futex_mutex.cc
@@ -32,7 +32,7 @@ static long futex_wakeN(volatile int *addr) {
 }
 
 static const int lock_spin_count = 20;
-static const int unlock_spin_count = 20;
+// static const int unlock_spin_count = 20;
 
 // Return 0 if it's a fast acquiistion, 1 if slow
 extern "C" int futex_mutex_lock(futex_mutex_t *m) {

--- a/src/huge_malloc.cc
+++ b/src/huge_malloc.cc
@@ -10,7 +10,7 @@
 #include "generated_constants.h"
 #include "malloc_internal.h"
 
-static lock_t huge_lock = LOCK_INITIALIZER;
+static lock_t huge_lock = {LOCK_INITIALIZER};
 
 // free_chunks[0] is a list of 1-chunk objects (which are, by definition chunk-aligned)
 // free_chunks[1] is a list of 2-chunk objects which are also 2-chunk aligned (that is 4MiB-aligned).

--- a/src/large_malloc.cc
+++ b/src/large_malloc.cc
@@ -19,7 +19,7 @@ static const binnumber_t n_large_classes = first_huge_bin_number - first_large_b
 static large_object_list_cell* free_large_objects[n_large_classes]; // For each large size, a list (threaded through the chunk headers) of all the free objects of that size.
 // Later we'll be a little careful about purging those large objects (and we'll need to remember which are which, but we may also want thread-specific parts).  For now, just purge them all.
 
-static lock_t large_lock = LOCK_INITIALIZER;
+static lock_t large_lock = {LOCK_INITIALIZER};
 
 void predo_large_malloc_pop(large_object_list_cell **free_head) {
   // For the predo, we basically want to look at the free head (and make it writeable) and

--- a/src/malloc.cc
+++ b/src/malloc.cc
@@ -79,7 +79,7 @@ uint32_t n_cores;
 #ifdef DO_FAILED_COUNTS
 atomic_stats_s atomic_stats;
 
-lock_t failed_counts_mutex = LOCK_INITIALIZER;
+lock_t failed_counts_mutex = {LOCK_INITIALIZER};
 int    failed_counts_n = 0;
 struct failed_counts_s failed_counts[max_failed_counts];
 

--- a/src/objsizes.cc
+++ b/src/objsizes.cc
@@ -280,7 +280,7 @@ done_small:
       objsize -= pagesize; 
       comment = " (reserve a page for the list of sizes)";
     }
-    struct static_bin_t b(BIN_LARGE, objsize);
+    class static_bin_t b(BIN_LARGE, objsize);
     b.print(cf, bin++);
     fprintf(cf, " %s\n", comment);
     static_bins.push_back(b);
@@ -289,7 +289,7 @@ done_small:
   binnumber_t first_huge_bin = bin;
   fprintf(cf, "// huge objects (chunk allocated) start  at this size.\n");
   for (uint64_t siz = chunksize; siz < (1ul<<48); siz*=2) {
-    struct static_bin_t b(BIN_HUGE, siz);
+    class static_bin_t b(BIN_HUGE, siz);
     b.print(cf, bin++);
     fprintf(cf, "\n");
   }

--- a/src/small_malloc.cc
+++ b/src/small_malloc.cc
@@ -4,7 +4,7 @@
 #include "malloc_internal.h"
 #include <sys/mman.h>
 
-lock_t small_locks[first_large_bin_number] = { REPEAT_FOR_SMALL_BINS(LOCK_INITIALIZER) };
+lock_t small_locks[first_large_bin_number] = { REPEAT_FOR_SMALL_BINS({LOCK_INITIALIZER}) };
 
 static struct {
   dynamic_small_bin_info lists __attribute__((aligned(4096)));


### PR DESCRIPTION
Here are the error messages I fixed:

error: struct 'static_bin_t' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
solution: change "struct" -> "class"
../src/objsizes.cc:292:5
../src/objsizes.cc:283:5

error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
solution: adding braces is a no-brainer; doesn't change the meaning of code.
../src/large_malloc.cc:22:28
../src/huge_malloc.cc:13:27
../src/small_malloc.cc:7:70

error: unknown attribute 'optimize' ignored [-Werror,-Wunknown-attributes]
solution: guard the GCC loop-unrolling directive, so that it is only enabled in GCC, and add a clang-guarded loop-unrolling directive
../src/cache.cc:358:16
../src/cache.cc:370:16
../src/cache.cc:679:16
../src/cache.cc:694:16

error: unused variable 'unlock_spin_count' [-Werror,-Wunused-const-variable]
solution: comment out
../src/futex_mutex.cc:35:18